### PR TITLE
Add libp2p relay server CLI command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+isek0.3/
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ In the examples folder, follow the examples from level 1 to level 10, and you sh
 ## 🧪 CLI Commands
 
 ```bash
-isek setup       # Install Python and JavaScript dependencies
-isek clean       # Clean temporary files
-isek --help      # View available commands
+isek setup            # Install Python and JavaScript dependencies
+isek clean            # Clean temporary files
+isek run relay        # Start a libp2p circuit relay server (default port: 9090)
+isek run relay --port=8080  # Start relay on custom port
+isek --help           # View available commands
 ```
 
 ---

--- a/isek/cli.py
+++ b/isek/cli.py
@@ -68,6 +68,70 @@ def registry():
     main()
 
 
+@cli.group()
+def run():
+    """Run ISEK servers and services"""
+
+
+@run.command()
+@click.option(
+    "--port", default=9090, type=int, help="Port for the relay server (default: 9090)"
+)
+def relay(port):
+    """Start a libp2p circuit relay server"""
+    import importlib.resources
+
+    # Find the p2p directory
+    try:
+        p2p_resource = importlib.resources.files("isek").joinpath("protocol/p2p")
+        p2p_dir = Path(str(p2p_resource))
+    except Exception:
+        # Fallback to development environment path
+        p2p_dir = Path(__file__).parent / "protocol" / "p2p"
+
+    relay_script = p2p_dir / "relay.js"
+
+    # Check if relay.js exists
+    if not relay_script.exists():
+        click.secho(f"✗ Relay script not found at {relay_script}", fg="red")
+        sys.exit(1)
+
+    # Check if Node.js is installed
+    try:
+        subprocess.run(["node", "--version"], check=True, capture_output=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        click.secho("✗ Node.js is required to run the relay server", fg="red")
+        click.secho("   Please install Node.js from https://nodejs.org/", fg="yellow")
+        sys.exit(1)
+
+    # Check if node_modules exists
+    if not (p2p_dir / "node_modules").exists():
+        click.secho("✗ JavaScript dependencies not installed", fg="red")
+        click.secho(
+            "   Please run 'isek setup' first to install dependencies", fg="yellow"
+        )
+        sys.exit(1)
+
+    # Validate port range
+    if port <= 0 or port >= 65536:
+        click.secho(f"✗ Invalid port: {port}. Must be between 1 and 65535", fg="red")
+        sys.exit(1)
+
+    click.secho(f"🚀 Starting libp2p relay server on port {port}...", fg="blue")
+    click.secho("   Press Ctrl+C to stop", fg="yellow")
+
+    # Run the relay server
+    try:
+        subprocess.run(
+            ["node", str(relay_script), f"--port={port}"], cwd=p2p_dir, check=True
+        )
+    except KeyboardInterrupt:
+        click.secho("\n✓ Relay server stopped", fg="green")
+    except subprocess.CalledProcessError as e:
+        click.secho(f"\n✗ Relay server failed: {e}", fg="red")
+        sys.exit(e.returncode)
+
+
 @cli.command()
 def setup():
     """Install ISEK Python and JavaScript dependencies"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     
     # Web3/Ethereum dependencies
     "web3>=6.0.0",
-    "eth-account>=0.9.0",
+    "eth-account>=0.8.0,<0.9.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Add new `isek run relay` CLI command to start a libp2p circuit relay server
- Support custom port configuration with default port 9090
- Include comprehensive error handling and input validation
- Update README documentation with new CLI commands
- Exclude isek0.3/ directory from git tracking

## Test plan
- [ ] Test `isek run relay` command with default port
- [ ] Test `isek run relay --port=8080` with custom port  
- [ ] Verify error handling for invalid ports and missing dependencies
- [ ] Test Node.js installation check
- [ ] Verify relay server functionality

🤖 Generated with [Claude Code](https://claude.ai/code)